### PR TITLE
Fix: Enable IAP API for OAuth brand creation

### DIFF
--- a/src/main/services/deploymentEngine.ts
+++ b/src/main/services/deploymentEngine.ts
@@ -407,6 +407,7 @@ export class DeploymentEngine extends EventEmitter {
       'apikeys.googleapis.com',
       'identitytoolkit.googleapis.com', // Firebase Auth API
       'aiplatform.googleapis.com', // Vertex AI API
+      'iap.googleapis.com', // Identity-Aware Proxy API for OAuth brands
     ];
     
     this.emitProgress({


### PR DESCRIPTION
## Summary
- Adds `iap.googleapis.com` to the list of APIs enabled during deployment
- Fixes the 'SERVICE_DISABLED' error when creating IAP OAuth brands
- Only enabled for Vertex AI mode (not needed for AI Studio mode as confirmed)

## Problem
When IAP OAuth setup runs, it fails with:
```
Cloud Identity-Aware Proxy API has not been used in project before or it is disabled
```

## Solution
Enable the IAP API along with other APIs during the deployment process.

## Testing
Manually tested on project testreal-ee5d:
1. Enabled IAP API: ✅ Success
2. Created IAP OAuth brand: ✅ Success  
3. Created OAuth client: ✅ Success (ID: 619813188397-vggljvk2tuaiuoon4iakbnrjaj5970oa.apps.googleusercontent.com)

This enables fully automated Google Sign-In setup via IAP OAuth.